### PR TITLE
fix for the python Notebook and EarthLocation representation warning/…

### DIFF
--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -253,9 +253,9 @@ class EarthLocation(u.Quantity):
                   this returns.
         """
         return cls._get_site_registry().names
-
+    # to fix the ipython warning Could not access the online site list.
     @classmethod
-    def _get_site_registry(cls, force_download=False, force_builtin=False):
+    def _get_site_registry(cls, force_download=True, force_builtin=False):
         """
         Gets the site registry.  The first time this either downloads or loads
         from the data file packaged with astropy.  Subsequent calls will use the


### PR DESCRIPTION
![screenshot from 2016-02-03 15 43 57](https://cloud.githubusercontent.com/assets/16108341/12779509/59ceb2c6-ca8e-11e5-9a6e-769d31336c03.png)
…error #4542

to fix the issue we need to overide the _get_site_registry method with TRUE ATTRIBUTE FOR FORCE DOWNLOAD. Because ipython is not compatible to download by default from url
