### PR TITLE
final fix for the Ipython Notebook and EarthLocation representation w…

### DIFF
--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -19,11 +19,11 @@ from ...utils.xml import writer
 from copy import deepcopy
 
 try:
-  import lxml
+    import lxml
 except ImportError:
-  lxml_installed = False
+    lxml_installed = False
 else:
-  lxml_installed = True
+    lxml_installed = True
 
 class SoupString(str):
     """
@@ -91,9 +91,9 @@ class HTMLInputter(core.BaseInputter):
 
         if 'parser' not in self.html:
             if lxml_installed:
-              soup = BeautifulSoup('\n'.join(lines),"lxml")
+                soup = BeautifulSoup('\n'.join(lines),"lxml")
             else:
-              soup = BeautifulSoup('\n'.join(lines),"html.parser")
+                soup = BeautifulSoup('\n'.join(lines),"html.parser")
         else: # use a custom backend parser
             soup = BeautifulSoup('\n'.join(lines), self.html['parser'])
         tables = soup.find_all('table')

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -101,8 +101,8 @@ class Latex(base.Base):
         -------
         latex_string : str
             The value in exponential notation in a format suitable for LaTeX.
-        """
-        if np.isfinite(val):
+        """#np.any() and np.all() which to use depends on the val array
+        if np.any(np.isfinite(val)):   #np.isfinite returns a booleans of array type so np.any(np.ndarray) returns true if any vaues in np.ndarray is true
             m, ex = utils.split_mantissa_exponent(val)
 
             parts = []

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -102,7 +102,10 @@ class Latex(base.Base):
         latex_string : str
             The value in exponential notation in a format suitable for LaTeX.
         """
-        if np.any(np.isfinite(val)):   #np.isfinite returns a booleans of array type so np.any(np.ndarray) returns true if any vaues in np.ndarray is true
+        """ np.isfinite returns a booleans of array type so np.any(np.ndarray)
+            returns true if any vaues in np.ndarray is true.
+        """
+        if np.any(np.isfinite(val)):
             m, ex = utils.split_mantissa_exponent(val)
 
             parts = []
@@ -116,13 +119,15 @@ class Latex(base.Base):
             if np.isnan(val):
                 return r'{\rm NaN}'
             elif val > 0:
-                #positive infinity
+                # positive infinity
                 return r'\infty'
             else:
-                #negative infinity
+                # negative infinity
                 return r'-\infty'
 
+
 class LatexInline(Latex):
+
     """
     Output LaTeX to display the unit based on IAU style guidelines with negative
     powers.

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -101,7 +101,7 @@ class Latex(base.Base):
         -------
         latex_string : str
             The value in exponential notation in a format suitable for LaTeX.
-        """#np.any() and np.all() which to use depends on the val array
+        """
         if np.any(np.isfinite(val)):   #np.isfinite returns a booleans of array type so np.any(np.ndarray) returns true if any vaues in np.ndarray is true
             m, ex = utils.split_mantissa_exponent(val)
 


### PR DESCRIPTION
…arning/error #4542  (ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all())

The error message explains it pretty well:
ValueError: The truth value of an array with more than one element is ambiguous. 
Use a.any() or a.all()
What should bool(np.array([False, False, True])) return? You can make several plausible arguments:
(1) True, because bool(np.array(x)) should return the same as bool(list(x)), and non-empty lists are truelike;
(2) True, because at least one element is True;
(3) False, because not all elements are True;
and that's not even considering the complexity of the N-d case.
So, since "the truth value of an array with more than one element is ambiguous", you should use .any() or .all(), for example:
so the fix is to use np.all(array([ True,  True, False], dtype=bool))
or 
np.any(array([ True,  True, False], dtype=bool))
